### PR TITLE
fix issue to run docker:build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,6 +223,13 @@
                 <plugin>
                     <groupId>com.spotify</groupId>
                     <artifactId>docker-maven-plugin</artifactId>
+                    <dependencies>
+                        <dependency>
+                            <groupId>javax.activation</groupId>
+                            <artifactId>activation</artifactId>
+                            <version>1.1.1</version>
+                        </dependency>
+                    </dependencies>
                     <version>${docker.maven.plugin.version}</version>
                     <!--<executions>-->
                         <!--<execution>-->


### PR DESCRIPTION
Fix the issue to run mvn docker:build with openjdk version "11.0.8"

It throw the error when run "mvn docker:build" with openjdk version "11.0.8"


WARNING: HK2 service reification failed for [com.spotify.docker.client.shaded.org.glassfish.jersey.message.internal.DataSourceProvider] with an exception:
MultiException stack 1 of 2
java.lang.NoClassDefFoundError: javax/activation/DataSource
        at java.base/java.lang.Class.getDeclaredConstructors0(Native Method)
        at java.base/java.lang.Class.privateGetDeclaredConstructors(Class.java:3137)
        at java.base/java.lang.Class.getDeclaredConstructors(Class.java:2357)
        at com.spotify.docker.client.shaded.org.jvnet.hk2.internal.Utilities$3.run(Utilities.java:1310)
        at com.spotify.docker.client.shaded.org.jvnet.hk2.internal.Utilities$3.run(Utilities.java:1306)
        at java.base/java.security.AccessController.doPrivileged(Native Method)
        at com.spotify.docker.client.shaded.org.jvnet.hk2.internal.Utilities.getAllConstructors(Utilities.java:1306)
        at com.spotify.docker.client.shaded.org.jvnet.hk2.internal.Utilities.findProducerConstructor(Utilities.java:1249)
        at com.spotify.docker.client.shaded.org.jvnet.hk2.internal.DefaultClassAnalyzer.getConstructor(DefaultClassAnalyzer.java:83)
        at com.spotify.docker.client.shaded.org.glassfish.jersey.internal.inject.JerseyClassAnalyzer.getConstructor(JerseyClassAnalyzer.java:144)
        at com.spotify.docker.client.shaded.org.jvnet.hk2.internal.Utilities.getConstructor(Utilities.java:178)
        at com.spotify.docker.client.shaded.org.jvnet.hk2.internal.ClazzCreator.initialize(ClazzCreator.java:128)
        at com.spotify.docker.client.shaded.org.jvnet.hk2.internal.ClazzCreator.initialize(ClazzCreator.java:179)
        at com.spotify.docker.client.shaded.org.jvnet.hk2.internal.SystemDescriptor.internalReify(SystemDescriptor.java:723)
        at com.spotify.docker.client.shaded.org.jvnet.hk2.internal.SystemDescriptor.reify(SystemDescriptor.java:678)
        at com.spotify.docker.client.shaded.org.jvnet.hk2.internal.ServiceLocatorImpl.reifyDescriptor(ServiceLocatorImpl.java:458)
        at com.spotify.docker.client.shaded.org.jvnet.hk2.internal.ServiceLocatorImpl.narrow(ServiceLocatorImpl.java:2205)
        at com.spotify.docker.client.shaded.org.jvnet.hk2.internal.ServiceLocatorImpl.access$1200(ServiceLocatorImpl.java:122)
        at com.spotify.docker.client.shaded.org.jvnet.hk2.internal.ServiceLocatorImpl$9.compute(ServiceLocatorImpl.java:1350)
        at com.spotify.docker.client.shaded.org.jvnet.hk2.internal.ServiceLocatorImpl$9.compute(ServiceLocatorImpl.java:1345)
        at com.spotify.docker.client.shaded.org.glassfish.hk2.utilities.cache.internal.WeakCARCacheImpl.compute(WeakCARCacheImpl.java:116)
        at com.spotify.docker.client.shaded.org.jvnet.hk2.internal.ServiceLocatorImpl.internalGetAllServiceHandles(ServiceLocatorImpl.java:1407)
        at com.spotify.docker.client.shaded.org.jvnet.hk2.internal.ServiceLocatorImpl.getAllServiceHandles(ServiceLocatorImpl.java:1332)
        at com.spotify.docker.client.shaded.org.jvnet.hk2.internal.ServiceLocatorImpl.getAllServiceHandles(ServiceLocatorImpl.java:1321)
        at com.spotify.docker.client.shaded.org.glassfish.jersey.internal.inject.Providers.getServiceHandles(Providers.java:354)
        at com.spotify.docker.client.shaded.org.glassfish.jersey.internal.inject.Providers.getProviders(Providers.java:187)
        at com.spotify.docker.client.shaded.org.glassfish.jersey.message.internal.MessageBodyFactory.<init>(MessageBodyFactory.java:248)
        at jdk.internal.reflect.GeneratedConstructorAccessor50.newInstance(Unknown Source)
        at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:490)
        at com.spotify.docker.client.shaded.org.glassfish.hk2.utilities.reflection.ReflectionHelper.makeMe(ReflectionHelper.java:1350)
        at com.spotify.docker.client.shaded.org.jvnet.hk2.internal.ClazzCreator.createMe(ClazzCreator.java:271)
        at com.spotify.docker.client.shaded.org.jvnet.hk2.internal.ClazzCreator.create(ClazzCreator.java:365)
        at com.spotify.docker.client.shaded.org.jvnet.hk2.internal.SystemDescriptor.create(SystemDescriptor.java:471)
        at com.spotify.docker.client.shaded.org.jvnet.hk2.internal.SingletonContext$1.compute(SingletonContext.java:83)
        at com.spotify.docker.client.shaded.org.jvnet.hk2.internal.SingletonContext$1.compute(SingletonContext.java:71)
        at com.spotify.docker.client.shaded.org.glassfish.hk2.utilities.cache.Cache$OriginThreadAwareFuture$1.call(Cache.java:97)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at com.spotify.docker.client.shaded.org.glassfish.hk2.utilities.cache.Cache$OriginThreadAwareFuture.run(Cache.java:154)
        at com.spotify.docker.client.shaded.org.glassfish.hk2.utilities.cache.Cache.compute(Cache.java:199)
        at com.spotify.docker.client.shaded.org.jvnet.hk2.internal.SingletonContext.findOrCreate(SingletonContext.java:122)
        at com.spotify.docker.client.shaded.org.jvnet.hk2.internal.Utilities.createService(Utilities.java:2022)
        at com.spotify.docker.client.shaded.org.jvnet.hk2.internal.ServiceLocatorImpl.internalGetService(ServiceLocatorImpl.java:765)
        at com.spotify.docker.client.shaded.org.jvnet.hk2.internal.ServiceLocatorImpl.getUnqualifiedService(ServiceLocatorImpl.java:772)
        at com.spotify.docker.client.shaded.org.jvnet.hk2.internal.IterableProviderImpl.get(IterableProviderImpl.java:111)
        at com.spotify.docker.client.shaded.org.glassfish.jersey.client.RequestProcessingInitializationStage.apply(RequestProcessingInitializationStage.java:97)
        at com.spotify.docker.client.shaded.org.glassfish.jersey.client.RequestProcessingInitializationStage.apply(RequestProcessingInitializationStage.java:67)
        at com.spotify.docker.client.shaded.org.glassfish.jersey.process.internal.Stages$LinkedStage.apply(Stages.java:308)
        at com.spotify.docker.client.shaded.org.glassfish.jersey.process.internal.Stages.process(Stages.java:171)
        at com.spotify.docker.client.shaded.org.glassfish.jersey.client.ClientRuntime$2.run(ClientRuntime.java:158)
        at com.spotify.docker.client.shaded.org.glassfish.jersey.internal.Errors$1.call(Errors.java:271)
        at com.spotify.docker.client.shaded.org.glassfish.jersey.internal.Errors$1.call(Errors.java:267)
        at com.spotify.docker.client.shaded.org.glassfish.jersey.internal.Errors.process(Errors.java:315)
        at com.spotify.docker.client.shaded.org.glassfish.jersey.internal.Errors.process(Errors.java:297)
        at com.spotify.docker.client.shaded.org.glassfish.jersey.internal.Errors.process(Errors.java:267)
        at com.spotify.docker.client.shaded.org.glassfish.jersey.process.internal.RequestScope.runInScope(RequestScope.java:340)
        at com.spotify.docker.client.shaded.org.glassfish.jersey.client.ClientRuntime$3.run(ClientRuntime.java:210)
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: java.lang.ClassNotFoundException: javax.activation.DataSource
        at org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy.loadClass(SelfFirstStrategy.java:50)
        at org.codehaus.plexus.classworlds.realm.ClassRealm.unsynchronizedLoadClass(ClassRealm.java:271)
        at org.codehaus.plexus.classworlds.realm.ClassRealm.loadClass(ClassRealm.java:247)
        at org.codehaus.plexus.classworlds.realm.ClassRealm.loadClass(ClassRealm.java:239)
        ... 62 more
MultiException stack 2 of 2