### PR TITLE
修复docker-compose部署时时区设置不生效的问题

### DIFF
--- a/document/docker/docker-compose-app.yml
+++ b/document/docker/docker-compose-app.yml
@@ -9,7 +9,7 @@ services:
       - /mydata/app/mall-admin/logs:/var/logs
       - /etc/localtime:/etc/localtime
     environment:
-      - 'TZ="Asia/Shanghai"'
+      - TZ=Asia/Shanghai
     external_links:
       - mysql:db #可以用db这个域名访问mysql服务
       - nacos-registry:nacos-registry #可以用nacos-registry这个域名访问nacos服务
@@ -22,7 +22,7 @@ services:
       - /mydata/app/mall-search/logs:/var/logs
       - /etc/localtime:/etc/localtime
     environment:
-      - 'TZ="Asia/Shanghai"'
+      - TZ=Asia/Shanghai
     external_links:
       - elasticsearch:es #可以用es这个域名访问elasticsearch服务
       - mysql:db #可以用db这个域名访问mysql服务
@@ -36,7 +36,7 @@ services:
       - /mydata/app/mall-portal/logs:/var/logs
       - /etc/localtime:/etc/localtime
     environment:
-      - 'TZ="Asia/Shanghai"'
+      - TZ=Asia/Shanghai
     external_links:
       - redis:redis #可以用redis这个域名访问redis服务
       - mongo:mongo #可以用mongo这个域名访问mongo服务
@@ -52,7 +52,7 @@ services:
       - /mydata/app/mall-auth/logs:/var/logs
       - /etc/localtime:/etc/localtime
     environment:
-      - 'TZ="Asia/Shanghai"'
+      - TZ=Asia/Shanghai
     external_links:
       - nacos-registry:nacos-registry #可以用nacos-registry这个域名访问nacos服务
   mall-gateway:
@@ -64,7 +64,7 @@ services:
       - /mydata/app/mall-gateway/logs:/var/logs
       - /etc/localtime:/etc/localtime
     environment:
-      - 'TZ="Asia/Shanghai"'
+      - TZ=Asia/Shanghai
     external_links:
       - redis:redis #可以用redis这个域名访问redis服务
       - nacos-registry:nacos-registry #可以用nacos-registry这个域名访问nacos服务
@@ -77,6 +77,6 @@ services:
       - /mydata/app/mall-monitor/logs:/var/logs
       - /etc/localtime:/etc/localtime
     environment:
-      - 'TZ="Asia/Shanghai"'
+      - TZ=Asia/Shanghai
     external_links:
       - nacos-registry:nacos-registry #可以用nacos-registry这个域名访问nacos服务


### PR DESCRIPTION
在docker-compose部署中，`- 'TZ="Asia/Shanghai"'`导致时区设置不生效，开始我以为是docker-compose的原因，安装了新版docker-compose，发现依然存在该问题，查看官方文档并调整后，能够设置成功

- [x] 已经过`date -R`命令测试

### 更改示例
更改前
```
version: '3'
services:
  mall-admin:
    image: mall/mall-admin:1.0-SNAPSHOT
    container_name: mall-admin
    environment:
      - 'TZ="Asia/Shanghai"'
```

更改后
```
version: '3'
services:
  mall-admin:
    image: mall/mall-admin:1.0-SNAPSHOT
    container_name: mall-admin
    environment:
      - TZ=Asia/Shanghai
```
### 文档资料
[https://docs.docker.com/compose/compose-file/compose-file-v3/#environment](https://docs.docker.com/compose/compose-file/compose-file-v3/#environment)


### 测试环境

- docker版本

```
[root@xyzh-it-framework-test01 app]# docker version
Client: Docker Engine - Community
 Version:           20.10.12
 API version:       1.41
 Go version:        go1.16.12
 Git commit:        e91ed57
 Built:             Mon Dec 13 11:45:41 2021
 OS/Arch:           linux/amd64
 Context:           default
 Experimental:      true

Server: Docker Engine - Community
 Engine:
  Version:          20.10.12
  API version:      1.41 (minimum version 1.12)
  Go version:       go1.16.12
  Git commit:       459d0df
  Built:            Mon Dec 13 11:44:05 2021
  OS/Arch:          linux/amd64
  Experimental:     false
 containerd:
  Version:          1.4.12
  GitCommit:        7b11cfaabd73bb80907dd23182b9347b4245eb5d
 runc:
  Version:          1.0.2
  GitCommit:        v1.0.2-0-g52b36a2
 docker-init:
  Version:          0.19.0
  GitCommit:        de40ad0
```

- docker-compose版本
```
[root@xyzh-it-framework-test01 app]# docker-compose version
docker-compose version 1.29.2, build 5becea4c
docker-py version: 5.0.0
CPython version: 3.7.10
OpenSSL version: OpenSSL 1.1.0l  10 Sep 2019
```